### PR TITLE
fix google submit form

### DIFF
--- a/Controls/InfoViewer.cs
+++ b/Controls/InfoViewer.cs
@@ -33,6 +33,7 @@ namespace ConsoleServiceTool.Controls
             WebViewMain.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
             WebViewMain.CoreWebView2.Settings.AreDevToolsEnabled = false;
             WebViewMain.CoreWebView2.Settings.IsStatusBarEnabled = false;
+            WebViewMain.CoreWebView2.Profile.PreferredTrackingPreventionLevel = CoreWebView2TrackingPreventionLevel.Basic;
         }
 
         private void CoreWebView2_NavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)


### PR DESCRIPTION
by default tracking level of webview is set to Balanced but this blocks the google form from being loaded. 
By setting it to Basic the form can be loaded but uncle google will track your steps.